### PR TITLE
Add minimal Flutter setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,20 @@
 # Projekt-1
+
+Dieses Repository enthält eine minimale Flutter-Anwendung im Verzeichnis `flutter_app`.
+
+## Voraussetzungen
+- [Flutter SDK](https://docs.flutter.dev/get-started/install) muss installiert sein.
+
+## Projektstruktur
+```
+flutter_app/
+  lib/
+    main.dart
+  pubspec.yaml
+```
+
+## App starten
+```
+cd flutter_app
+flutter run
+```

--- a/flutter_app/lib/main.dart
+++ b/flutter_app/lib/main.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+void main() {
+  runApp(const MyApp());
+}
+
+class MyApp extends StatelessWidget {
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return const MaterialApp(
+      home: Scaffold(
+        body: Center(
+          child: Text('Hello, Flutter!'),
+        ),
+      ),
+    );
+  }
+}

--- a/flutter_app/pubspec.yaml
+++ b/flutter_app/pubspec.yaml
@@ -1,0 +1,18 @@
+name: flutter_app
+version: 0.1.0
+publish_to: 'none'
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+
+  cupertino_icons: ^1.0.2
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
+flutter:
+  uses-material-design: true


### PR DESCRIPTION
## Summary
- set up a basic Flutter project under `flutter_app`
- provide run instructions in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685191c8aff4832c8edc47afd8f498d3